### PR TITLE
Fixing typo causing error while importing drafting.py

### DIFF
--- a/src/cq_warehouse/drafting.py
+++ b/src/cq_warehouse/drafting.py
@@ -28,7 +28,7 @@ license:
 
 """
 from math import floor, log2, gcd, pi
-from typing import Union, Tuple, Literal, Optional, ClassVar, Any
+from typing import Union, Tuple, Literal, Optional, ClassVar, Any, List
 
 """# pylint: disable=no-name-in-module"""
 from pydantic import BaseModel, PrivateAttr, validator, validate_arguments
@@ -41,7 +41,7 @@ INCH = 25.4 * MM
 
 VectorLike = Union[Tuple[float, float, float], cq.Vector]
 PathDescriptor = Union[
-    cq.Wire, cq.Edge, list[Union[cq.Vector, cq.Vertex, Tuple[float, float, float]]],
+    cq.Wire, cq.Edge, List[Union[cq.Vector, cq.Vertex, Tuple[float, float, float]]],
 ]
 PointDescriptor = Union[cq.Vector, cq.Vertex, Tuple[float, float, float]]
 

--- a/src/cq_warehouse/drafting.py
+++ b/src/cq_warehouse/drafting.py
@@ -184,7 +184,7 @@ class Draft(BaseModel):
     ) -> str:
         """ Convert a raw number to a unit of measurement string based on the class settings """
 
-        def simplify_fraction(numerator: int, denominator: int) -> tuple[int, int]:
+        def simplify_fraction(numerator: int, denominator: int) -> Tuple[int, int]:
             """ Mathematically simplify a fraction given a numerator and demoninator """
             greatest_common_demoninator = gcd(numerator, denominator)
             return (


### PR DESCRIPTION
Was getting this error below when importing drafting.py. It was a trivial change.

```
[GCC 7.5.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from cq_warehouse.drafting import Draft
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/safdar/code/repositories/cq_warehouse/src/cq_warehouse/drafting.py", line 44, in <module>
    cq.Wire, cq.Edge, list[Union[cq.Vector, cq.Vertex, Tuple[float, float, float]]],
TypeError: 'type' object is not subscriptable
>>> 
```

And another:
```
~/code/repositories/cq_warehouse/src/cq_warehouse/drafting.py in _number_with_units(self, number, tolerance, display_units)
    185         """ Convert a raw number to a unit of measurement string based on the class settings """
    186 
--> 187         def simplify_fraction(numerator: int, denominator: int) -> tuple[int, int]:
    188             """ Mathematically simplify a fraction given a numerator and demoninator """
    189             greatest_common_demoninator = gcd(numerator, denominator)

TypeError: 'type' object is not subscriptable
```