### PR TITLE
Fixes fit of M8-1.25 Brad Tee Nut Normal Fit

### DIFF
--- a/src/cq_warehouse/brad_tee_nut_parameters.csv
+++ b/src/cq_warehouse/brad_tee_nut_parameters.csv
@@ -1,4 +1,4 @@
 Size,Hilitchi:s,Hilitchi:m,Hilitchi:dc,Hilitchi:c,Hilitchi:bcd,Hilitchi:brad_size,Hilitchi:brad_num
 M6-1,5.95,16.5,36.3,2.4,24,M4-0.7,3
-M8-1.25,5.95,16.5,36.3,2.4,24,M4-0.7,3
+M8-1.25,5.95,16.5,36,2.00,24,M4-0.7,3
 M10-1.5,5.95,16.5,36.3,2.4,24,M4-0.7,3


### PR DESCRIPTION
Nut tee now has enough space such that the plate aligns flush with the slab, and plate diameter also is not as loose for a normal fit
![image](https://user-images.githubusercontent.com/6283745/176987575-828710d1-1a93-418f-ad99-057843e5674b.png)
