### PR TITLE
Fixing readthedocs diagrams

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,8 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "3.9"
+  apt_packages:
+    - graphviz
 
 # Build from the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Add graphviz to readthedocs yaml to allow diagrams to be created.